### PR TITLE
wp_mailが発動しなかった時はfalseを返すようにした

### DIFF
--- a/postman.class.php
+++ b/postman.class.php
@@ -101,7 +101,7 @@ class Postman
 
     if (!$this->results) return false;
 
-    $result = true;
+    $result = false;
 
     $templates = $this->get_templates();
 

--- a/postman.class.php
+++ b/postman.class.php
@@ -107,7 +107,7 @@ class Postman
 
     $types = $this->get('_type');
 
-    if (!$types) return true;
+    if (!$types) return false;
 
     if (!is_array($types)) $types = array($types);
 


### PR DESCRIPTION
テーマ側で指定した`key: _types`が間違っていた場合、
`$types`配列の全ての値が`$templates`に一致せず、`wp_mail`は発動しません。
https://github.com/cinra/the-postman/blob/feature/mail_returnvalue/postman.class.php#L117

その場合、メールが送信されないのにエラーと判別されず、`true`と返ってしまうので
とりいそぎ`$result`のデフォルトを`false`としました。

ただ、mail関数のフォールバック自体もう少し見直しても良さそうなので、
（返り値を`$results`に集約するなら、wp_mailの返り値:配列と真偽分けて整理する、それに合わせて`die`の中身を細分化して制御する、など）
別branchで作業して改めてPR送ります。

